### PR TITLE
Improve documentation for plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,10 +600,16 @@ config
   .init((Plugin, args) => new Plugin(...args));
 ```
 
+#### Config plugins: removing
+
+```js
+config.plugins.delete(name)
+```
+
 #### Config resolve plugins
 
 ```js
-// Backed at config.plugins
+// Backed at config.resolve.plugins
 config.resolve.plugin(name) : ChainedMap
 ```
 
@@ -617,7 +623,7 @@ config.resolve
   .use(WebpackPlugin, args)
 ```
 
-#### Config plugins: modify arguments
+#### Config resolve plugins: modify arguments
 
 ```js
 config.resolve
@@ -625,12 +631,18 @@ config.resolve
   .tap(args => newArgs)
 ```
 
-#### Config plugins: modify instantiation
+#### Config resolve plugins: modify instantiation
 
 ```js
 config.resolve
   .plugin(name)
   .init((Plugin, args) => new Plugin(...args))
+```
+
+#### Config resolve plugins: removing
+
+```js
+config.resolve.plugins.delete(name)
 ```
 
 #### Config node


### PR DESCRIPTION
Adds examples for deleting plugins (to make it clearer that the `.delete()` must be applied to the backing set and not using the shorthand form), and corrects some typos.