### PR TITLE
Introduce method for performing a batch of operations against a context

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,13 @@ merge(obj, omit)
 ```
 
 ```js
+// Execute a function against the current configuration context
+// handler: Function -> ChainedMap
+  // A function which is given a single argument of the ChainedMap instance
+batch(handler)
+```
+
+```js
 // Conditionally execute a function to continue configuration
 // condition: Boolean
 // whenTruthy: Function -> ChainedMap
@@ -268,6 +275,13 @@ values()
 // Concatenates the given array to the end of the backing Set.
 // arr: Array
 merge(arr)
+```
+
+```js
+// Execute a function against the current configuration context
+// handler: Function -> ChainedSet
+  // A function which is given a single argument of the ChainedSet instance
+batch(handler)
 ```
 
 ```js

--- a/src/Chainable.js
+++ b/src/Chainable.js
@@ -3,6 +3,11 @@ module.exports = class {
     this.parent = parent;
   }
 
+  batch(handler) {
+    handler(this);
+    return this;
+  }
+
   end() {
     return this.parent;
   }

--- a/test/Chainable.js
+++ b/test/Chainable.js
@@ -7,3 +7,12 @@ test('Calling .end() returns parent', t => {
 
   t.is(chain.end(), parent);
 });
+
+test('Using .batch() receives context', t => {
+  const chain = new Chainable();
+  const context = chain.batch((current) => {
+    t.is(current, chain);
+  });
+
+  t.is(context, chain);
+});


### PR DESCRIPTION
Allows passing a function to execute against a certain context. Basically the non-conditional version of `.when()`.

```js
config
  .resolve
    .batch((resolve) => {
      resolve.modules.add(MODULES);
      resolve.extensions.add('.jsx');
      resolve.alias.set('react-native', 'react-native-web');
    });
```

```js
config
  .resolve
    .batch(({ modules, extensions, alias }) => {
      modules.add(MODULES);
      extensions.add('.jsx');
      alias.set('react-native', 'react-native-web');
    });
```

Helps avoid things like:

```js
config
  .resolve
    .modules
      .add(MODULES)
      .end()
    .extensions
      .add('.jsx')
      .end()
    .alias
      .set('react-native', 'react-native-web');
```